### PR TITLE
added Portuguese translation to spec file.

### DIFF
--- a/build/apt-dater.spec.in
+++ b/build/apt-dater.spec.in
@@ -89,3 +89,4 @@ make clean
 %{_mandir}/manh/*
 %lang(de) %{_datadir}/locale/de/LC_MESSAGES/apt-dater.mo
 %lang(it) %{_datadir}/locale/it/LC_MESSAGES/apt-dater.mo
+%lang(pt) %{_datadir}/locale/pt/LC_MESSAGES/apt-dater.mo


### PR DESCRIPTION
Hallo,

I tried to compile apt-dater on Fedora 21 and noticed, that the Portuguese translation file was missing in the spec file. So I added it. Now it compiles and builds. 

Mebus
