### PR TITLE
Fix sh string comparison in ssh-addonce

### DIFF
--- a/lib/ssh-addonce
+++ b/lib/ssh-addonce
@@ -24,7 +24,7 @@
 #   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 #
 
-if [ "$#" == "0" ]; then
+if [ "$#" = "0" ]; then
     echo "Usage: $0 <keyfile> ..." 1>&2
     exit 1
 fi


### PR DESCRIPTION
Replace bashism with single equal character. This will get rid of the error: ssh-addonce: 27: [: 1: unexpected operator