### PR TITLE
Use "$localstatedir" instead of hardcoding "/var"

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -18,6 +18,6 @@ install-exec-hook:
 	ln -s ../../../$(pkglibdir)/tmux-hint $(DESTDIR)$(sysconfdir)/apt-dater/post-upg.d/
 	$(mkinstalldirs) -m 0710 $(DESTDIR)$(sysconfdir)/apt-dater/ssh
 	$(INSTALL) -m 0640 $(EXTRA_DISTS) $(DESTDIR)$(sysconfdir)/apt-dater/
-	$(mkinstalldirs) -m 02770 $(DESTDIR)/var/lib/apt-dater/history/
-	$(mkinstalldirs) -m 02770 $(DESTDIR)/var/cache/apt-dater/stats/
-	$(mkinstalldirs) -m 02770 $(DESTDIR)/var/cache/apt-dater/tmux/
+	$(mkinstalldirs) -m 02770 $(DESTDIR)$(localstatedir)/lib/apt-dater/history/
+	$(mkinstalldirs) -m 02770 $(DESTDIR)$(localstatedir)/cache/apt-dater/stats/
+	$(mkinstalldirs) -m 02770 $(DESTDIR)$(localstatedir)/cache/apt-dater/tmux/

--- a/etc/Makefile.in
+++ b/etc/Makefile.in
@@ -460,9 +460,9 @@ install-exec-hook:
 	ln -s ../../../$(pkglibdir)/tmux-hint $(DESTDIR)$(sysconfdir)/apt-dater/post-upg.d/
 	$(mkinstalldirs) -m 0710 $(DESTDIR)$(sysconfdir)/apt-dater/ssh
 	$(INSTALL) -m 0640 $(EXTRA_DISTS) $(DESTDIR)$(sysconfdir)/apt-dater/
-	$(mkinstalldirs) -m 02770 $(DESTDIR)/var/lib/apt-dater/history/
-	$(mkinstalldirs) -m 02770 $(DESTDIR)/var/cache/apt-dater/stats/
-	$(mkinstalldirs) -m 02770 $(DESTDIR)/var/cache/apt-dater/tmux/
+	$(mkinstalldirs) -m 02770 $(DESTDIR)$(localstatedir)/lib/apt-dater/history/
+	$(mkinstalldirs) -m 02770 $(DESTDIR)$(localstatedir)/cache/apt-dater/stats/
+	$(mkinstalldirs) -m 02770 $(DESTDIR)$(localstatedir)/cache/apt-dater/tmux/
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.


### PR DESCRIPTION
This fixes "make install" for setups with own "prefix" settings,
because "$localstatedir" respects "$prefix".