### PR TITLE
Use localstatedir in stead of static /var

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -415,6 +415,7 @@ AC_CHECK_FUNCS([memset strchr strdup strerror])
 
 # Recursive eval some vars
 adl_RECURSIVE_EVAL([$sysconfdir], sysconfdir)
+adl_RECURSIVE_EVAL([$localstatedir], localstatedir)
 
 AC_CONFIG_FILES([ po/Makefile.in
 Makefile

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -18,6 +18,6 @@ install-exec-hook:
 	ln -s ../../../$(pkglibdir)/tmux-hint $(DESTDIR)$(sysconfdir)/apt-dater/post-upg.d/
 	$(mkinstalldirs) -m 0710 $(DESTDIR)$(sysconfdir)/apt-dater/ssh
 	$(INSTALL) -m 0640 $(EXTRA_DISTS) $(DESTDIR)$(sysconfdir)/apt-dater/
-	$(mkinstalldirs) -m 02770 $(DESTDIR)/var/lib/apt-dater/history/
-	$(mkinstalldirs) -m 02770 $(DESTDIR)/var/cache/apt-dater/stats/
-	$(mkinstalldirs) -m 02770 $(DESTDIR)/var/cache/apt-dater/tmux/
+	$(mkinstalldirs) -m 02770 $(DESTDIR)$(localstatedir)/lib/apt-dater/history/
+	$(mkinstalldirs) -m 02770 $(DESTDIR)$(localstatedir)/cache/apt-dater/stats/
+	$(mkinstalldirs) -m 02770 $(DESTDIR)$(localstatedir)/cache/apt-dater/tmux/

--- a/etc/Makefile.in
+++ b/etc/Makefile.in
@@ -460,9 +460,9 @@ install-exec-hook:
 	ln -s ../../../$(pkglibdir)/tmux-hint $(DESTDIR)$(sysconfdir)/apt-dater/post-upg.d/
 	$(mkinstalldirs) -m 0710 $(DESTDIR)$(sysconfdir)/apt-dater/ssh
 	$(INSTALL) -m 0640 $(EXTRA_DISTS) $(DESTDIR)$(sysconfdir)/apt-dater/
-	$(mkinstalldirs) -m 02770 $(DESTDIR)/var/lib/apt-dater/history/
-	$(mkinstalldirs) -m 02770 $(DESTDIR)/var/cache/apt-dater/stats/
-	$(mkinstalldirs) -m 02770 $(DESTDIR)/var/cache/apt-dater/tmux/
+	$(mkinstalldirs) -m 02770 $(DESTDIR)$(localstatedir)/lib/apt-dater/history/
+	$(mkinstalldirs) -m 02770 $(DESTDIR)$(localstatedir)/cache/apt-dater/stats/
+	$(mkinstalldirs) -m 02770 $(DESTDIR)$(localstatedir)/cache/apt-dater/tmux/
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/etc/apt-dater.xml.in
+++ b/etc/apt-dater.xml.in
@@ -40,8 +40,8 @@
     -->
     <paths
 	hosts-file="@sysconfdir@/apt-dater/hosts.xml"
-	history-dir="/var/lib/apt-dater/history"
-	stats-dir="/var/cache/apt-dater/stats"
+	history-dir="@localstatedir@/lib/apt-dater/history"
+	stats-dir="@localstatedir@/cache/apt-dater/stats"
 	umask="007"/>
 
     <!--
@@ -59,7 +59,7 @@
     - use shared socket path
     -->
     <tmux
-	socket-path="/var/cache/apt-dater/tmux"/>
+	socket-path="@localstatedir@/cache/apt-dater/tmux"/>
 
     <!--
 	 Colors      = (COMPONENT FG BG ';')*


### PR DESCRIPTION
This should fix `make install` when using e.g. `./configure --prefix=/usr/local`.
There's been a previous pull request #105 by @alexbarton which didn't seem to work for him, perhaps this would.
This seems to work for me, but let me know if there are any issues with these changes.