### PR TITLE
Change default screen socket dir on OS X

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -50,7 +50,11 @@ screen_get_sdir() {
   if (!pw)
     return NULL;
 
+  #ifndef __APPLE__
   g_snprintf(sdir, sizeof(sdir), SCREEN_SDFORMT, SCREEN_SOCKPATH, pw->pw_name);
+  #else
+  g_snprintf(sdir, sizeof(sdir), SCREEN_SDFORMT, SCREEN_SOCKPATH);
+  #endif
 
   return sdir;
 }

--- a/src/screen.h
+++ b/src/screen.h
@@ -32,7 +32,11 @@
 #include "apt-dater.h"
 #include "history.h"
 
+#ifndef __APPLE__
 #define SCREEN_SDFORMT "%s/S-%s"
+#else
+#define SCREEN_SDFORMT "%s/.screen"
+#endif
 #define SCREEN_SOCKPRE "apt-dater_"
 
 gboolean


### PR DESCRIPTION
Quick fix to support detecting screen sessions on OS X.
Without these changes apt-dater can't detect active screen sessions because OS X seems to use `.screen` the `S-<username>` format.