### PR TITLE
Provide tmux-bind-q-kill-pane hook

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,4 +1,4 @@
-EXTRA_DISTS=cmd hosts2xml ssh-addonce tmux-hint pcre-less
+EXTRA_DISTS=cmd hosts2xml ssh-addonce tmux-bind-q-kill-pane tmux-hint pcre-less
 
 install-exec-hook:
 	$(mkinstalldirs) $(DESTDIR)$(pkglibdir)

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -264,7 +264,7 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-EXTRA_DISTS = cmd hosts2xml ssh-addonce tmux-hint pcre-less
+EXTRA_DISTS = cmd hosts2xml ssh-addonce tmux-bind-q-kill-pane tmux-hint pcre-less
 all: all-am
 
 .SUFFIXES:

--- a/lib/tmux-bind-q-kill-pane
+++ b/lib/tmux-bind-q-kill-pane
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if [ -z "$TMUX_PANE" ]; then
+	exit 0
+fi
+
+case "$AD_ACTION" in
+refresh)
+	;;
+
+*)
+	tmux bind-key -T root q kill-pane
+	;;
+esac
+
+exit 0


### PR DESCRIPTION
This binds kill-pane to `q` (without prefix), similar to how old apt-dater+screen worked.