### PR TITLE
Automake requires a README

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
#135 breaks GNU standard (automake requires a README file), add symlink to README.md