### PR TITLE
differentiate security updates

### DIFF
--- a/src/apt-dater.h
+++ b/src/apt-dater.h
@@ -181,6 +181,7 @@ typedef enum {
 #ifdef FEAT_CLUSTERS
 #define HOST_STATUS_CLUSTERED       512
 #endif
+#define HOST_STATUS_PKGSECUPDATE   1024
 
 #define HOST_FORBID_REFRESH           1
 #define HOST_FORBID_UPGRADE           2

--- a/src/stats.c
+++ b/src/stats.c
@@ -323,6 +323,11 @@ gboolean getUpdatesFromStat(HostNode *n)
 	    pkgnode->flag = HOST_STATUS_PKGUPDATE;
 	    n->nupdates++;
 	    break;
+	case 'U':
+	    n->status = n->status | HOST_STATUS_PKGUPDATE | HOST_STATUS_PKGSECUPDATE;
+	    pkgnode->flag = HOST_STATUS_PKGUPDATE | HOST_STATUS_PKGSECUPDATE;
+	    n->nupdates++;
+	    break;
 	case 'h':
 	    n->status = n->status | HOST_STATUS_PKGKEPTBACK;
 	    pkgnode->flag = HOST_STATUS_PKGKEPTBACK;

--- a/src/ui.c
+++ b/src/ui.c
@@ -1476,7 +1476,9 @@ void drawPackageEntry (DrawNode *n)
  attron(n->attrs);
  mvremln(n->scrpos, 0, COLS);
 
- if(((PkgNode *) n->p)->flag & HOST_STATUS_PKGUPDATE)
+ if(((PkgNode *) n->p)->flag & HOST_STATUS_PKGSECUPDATE)
+   mvaddstr(n->scrpos, 7, "U:");
+ else if(((PkgNode *) n->p)->flag & HOST_STATUS_PKGUPDATE)
    mvaddstr(n->scrpos, 7, "u:");
  else if(((PkgNode *) n->p)->flag & HOST_STATUS_PKGKEPTBACK)
    mvaddstr(n->scrpos, 7, "h:");


### PR DESCRIPTION
This patch makes the UI display security updates with a 'U' instead of a 'u'.
    
The patch is the counterpart to this apt-dater-host commit ...

https://github.com/sourcepole/apt-dater-host/commit/8ac83e003c5aaff17d6fcaf5f0e4166b5d061640
    
... which make apt-dater-host report security updates with a flag 'U' instead of a 'u'.

Same as with 8ac83e0, this patch should be understood as a proof of concept that works.

What is missing from this patch is:

    a bump of the protocol version
    updates to the protocol documentation
    updates to report generation
    updates to the on screen help

I'd very much appreciate the inclusion of this /feature/. It does not need to be implemented the way I did it. In particular, maybe using a 'U' for signaling a security update could be debated and also the  "OR" logic which is used for the signaling of the HOST_STATUS_PKGSECUPDATE flag. 

I'd ask to please comment on this patch. (Merging it is of course also very fine ;-)