### PR TITLE
Move to next item on (un)tag

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -3684,6 +3684,7 @@ gboolean ctrlUI (GList *hosts)
     }
     drawEntry(n);
    } else beep();
+   refscr = ctrlKeyUpDown(KEY_DOWN);
    break;
 
 #ifdef FEAT_TCLFILTER


### PR DESCRIPTION
Move to the next list item on (un)tag.

This allows for slightly more efficient usage of tagging hosts.