### PR TITLE
Fix selection on rebuild when last item disappears.

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -2099,6 +2099,7 @@ void rebuildDrawList(GList *hosts)
    dl_new = g_list_nth(drawlist,j);
   }
  }
+ if (!selset) savesel = j-1;
 
  dl_new = g_list_nth(drawlist,savesel);
  if (dl_new) {


### PR DESCRIPTION
When performing an action on the very last entry in the drawlist that
causes it to move to another category, correctly select the last item
in the new drawlist, not the first (selset never gets set).

Signed-off-by: Mike Beattie <mike@ethernal.org>